### PR TITLE
Removed `.isel` for `DatasetRolling.construct` consistent rolling behavior.

### DIFF
--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -780,9 +780,7 @@ class DatasetRolling(Rolling["Dataset"]):
 
         attrs = self.obj.attrs if keep_attrs else {}
 
-        return Dataset(dataset, coords=self.obj.coords, attrs=attrs).isel(
-            {d: slice(None, None, s) for d, s in zip(self.dim, strides)}
-        )
+        return Dataset(dataset, coords=self.obj.coords, attrs=attrs)
 
 
 class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):


### PR DESCRIPTION
`Dataset(...).isel(...)` at the return caused `DatasetRolling.construct` behavior to be inconsistent with `DataArrayRolling.construct` when `stride` > 1 without any benefits.

The bug was reported in #7021

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #7021
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
